### PR TITLE
Add script/files for initial app conf

### DIFF
--- a/conf/nginx/flask.conf
+++ b/conf/nginx/flask.conf
@@ -1,0 +1,10 @@
+server {
+    listen 80;
+    server_name 0.0.0.0;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/conf/nginx/nginx.conf
+++ b/conf/nginx/nginx.conf
@@ -1,0 +1,49 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+        worker_connections 768;
+}
+
+http {
+
+        ##
+        # Basic Settings
+        ##
+
+        sendfile on;
+        tcp_nopush on;
+        types_hash_max_size 2048;
+
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+        client_max_body_size 20M;
+
+        ##
+        # SSL Settings
+        ##
+
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+        ssl_prefer_server_ciphers on;
+
+        ##
+        # Logging Settings
+        ##
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+
+        ##
+        # Gzip Settings
+        ##
+
+        gzip on;
+
+        ##
+        # Virtual Host Configs
+        ##
+
+        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/sites-enabled/*;
+}

--- a/conf/startup-script.sh
+++ b/conf/startup-script.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+sudo apt update && sudo apt install -y libpq-dev nginx python3-pip
+
+sudo systemctl start nginx
+sudo systemctl enable nginx
+
+sudo rm /etc/nginx/sites-available/*
+sudo rm /etc/nginx/sites-enabled/*
+
+ROOTDIR=/home/ubuntu/cloud_app
+sudo cp $ROOTDIR/conf/nginx/flask.conf /etc/nginx/sites-available/default
+sudo cp $ROOTDIR/conf/nginx/nginx.conf /etc/nginx/nginx.conf
+
+sudo ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+
+sudo systemctl restart nginx
+
+cd $ROOTDIR/app
+sudo pip install -r requirements.txt
+sudo echo "Running server..."
+sudo DB_URI=postgresql+psycopg2://myuser:mypassword@10.59.240.3:5432/appdb BROKER_URL=redis://10.128.0.4:6379/0 gunicorn app:app -w 4 --access-logfile - --error-logfile - --log-level info


### PR DESCRIPTION
This script is used when each machine is created/recreated in the instance group.

The startup-scritp for each machine is as follows:

```bash
#!/bin/bash

if [ ! -d "/home/ubuntu/cloud_app" ]; then
  sudo git clone https://github.com/Miso-Code/misw4204-aplicaciones-en-la-nube.git /home/ubuntu/cloud_app
fi

cd /home/ubuntu/cloud_app
sudo git pull --rebase

sudo ./conf/startup-script.sh
```